### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new ,:edit]
-  before_action :move_to_index, only: [:edit]
+  before_action :authenticate_user!, only: [:new ,:edit, :update]
+  before_action :move_to_index, only: [:edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
  def index
   @items = Item.all.order(id: "DESC")
  end
@@ -19,15 +20,12 @@ class ItemsController < ApplicationController
  end
 
  def show
-  @item = Item.find(params[:id])
  end
 
  def edit
-  @item = Item.find(params[:id])
  end
 
  def update
-   @item = Item.find(params[:id])
    if @item.update(item_params)
      redirect_to show
    else
@@ -44,5 +42,9 @@ class ItemsController < ApplicationController
  def move_to_index 
   @item = Item.find(params[:id])
   redirect_to root_path if current_user.id != @item.user_id
+ end
+
+ def set_item
+   @item = Item.find(params[:id])
  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new ,:edit, :update]
-  before_action :move_to_index, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new ,:create, :edit, :update]
   before_action :set_item, only: [:show, :edit, :update]
+  before_action :move_to_index, only: [:edit, :update]
  def index
   @items = Item.all.order(id: "DESC")
  end
@@ -27,7 +27,7 @@ class ItemsController < ApplicationController
 
  def update
    if @item.update(item_params)
-     redirect_to show
+     redirect_to item_path
    else
      render :edit
    end
@@ -40,7 +40,6 @@ class ItemsController < ApplicationController
  end
 
  def move_to_index 
-  @item = Item.find(params[:id])
   redirect_to root_path if current_user.id != @item.user_id
  end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
-
+  before_action :authenticate_user!, only: [:new ,:edit]
+  before_action :move_to_index, only: [:edit]
  def index
   @items = Item.all.order(id: "DESC")
  end
@@ -39,5 +39,10 @@ class ItemsController < ApplicationController
 
  def item_params
   params.require(:item).permit(:name, :explain, :category_id, :item_status_id, :shipping_fee_status_id, :shipping_fee_destination_id, :shipping_fee_day_id, :cost, :image).merge(user_id: current_user.id)
+ end
+
+ def move_to_index 
+  @item = Item.find(params[:id])
+  redirect_to root_path if current_user.id != @item.user_id
  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,6 +21,9 @@ class ItemsController < ApplicationController
  def show
   @item = Item.find(params[:id])
  end
+ 
+ def edit
+ end
 
  private 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,6 +26,15 @@ class ItemsController < ApplicationController
   @item = Item.find(params[:id])
  end
 
+ def update
+   @item = Item.find(params[:id])
+   if @item.update(item_params)
+     redirect_to show
+   else
+     render :edit
+   end
+ end
+
  private 
 
  def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,8 +21,9 @@ class ItemsController < ApplicationController
  def show
   @item = Item.find(params[:id])
  end
- 
+
  def edit
+  @item = Item.find(params[:id])
  end
 
  private 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with(model: @item, local: true) do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+     <%= render 'shared/error_messages', model: @item %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :explain, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:item_status_id, ItemStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_status_id, ShippingFeeStatus.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:shipping_fee_destination_id, ShippingFeeDestination.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_fee_day_id, ShippingFeeDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :cost, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -138,12 +136,10 @@ app/assets/stylesheets/items/new.css %>
       </p>
     </div>
     <%# /注意書き %>
-    <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= link_to 'もどる', item_path, class:"back-btn" %>
     </div>
-    <%# /下部ボタン %>
   </div>
   <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
-     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+     <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
      <p class="or-text">or</p>
      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit]
 end


### PR DESCRIPTION
# what
商品情報編集機能の実装
# why
商品情報編集機能を実装したかったため
[ログイン状態の出品者は、商品情報編集ページに遷移できる動画](https://gyazo.com/b14276218e30f655dfbf076781b8c899)
[正しく情報を記入すると、商品の情報を編集できる動画](https://gyazo.com/3f3247647faebd068541a5ba8852b639)
[入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画](https://gyazo.com/9c411eb396ae8bd4bf21524937022ebf)
[何も編集せずに更新をしても画像無しの商品にならない動画](https://gyazo.com/e1a48a73bde585bc9544d2c552c1e613)
[ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画](https://gyazo.com/c7170c72719b32a00263be3f7531e326)
[ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画](https://gyazo.com/7d0fdd3cd9bcd9b3cd6c0beddf1ae281)
[商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）](https://gyazo.com/a76793c9f82fdc26893c580458d448dd)